### PR TITLE
Start app with orientation locked to portrait

### DIFF
--- a/iOS/RCTOrientation/Orientation.m
+++ b/iOS/RCTOrientation/Orientation.m
@@ -20,7 +20,7 @@
 }
 
 #if (!TARGET_OS_TV)
-static UIInterfaceOrientationMask _orientationMask = UIInterfaceOrientationMaskAll;
+static UIInterfaceOrientationMask _orientationMask = UIInterfaceOrientationMaskPortrait;
 
 + (void)setOrientation: (UIInterfaceOrientationMask)orientationMask {
     _orientationMask = orientationMask;


### PR DESCRIPTION
Patch this line for portrait locked orientation when launching the app

### Before
```objective-c
static UIInterfaceOrientationMask _orientationMask = UIInterfaceOrientationMaskAll;
```

### After
```objective-c
static UIInterfaceOrientationMask _orientationMask = UIInterfaceOrientationMaskPortrait;
```